### PR TITLE
Migration auf Spring Boot 4.1.0

### DIFF
--- a/s2-spring-boot-foundation-basics/spring-boot-foundation-basics-final-tomcat/pom.xml
+++ b/s2-spring-boot-foundation-basics/spring-boot-foundation-basics-final-tomcat/pom.xml
@@ -31,7 +31,7 @@
 		<java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
     </properties>
 
     <dependencyManagement>

--- a/s2-spring-boot-foundation-basics/spring-boot-foundation-basics-final-tomcat/pom.xml
+++ b/s2-spring-boot-foundation-basics/spring-boot-foundation-basics-final-tomcat/pom.xml
@@ -49,7 +49,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/s2-spring-boot-foundation-basics/spring-boot-foundation-basics-final/pom.xml
+++ b/s2-spring-boot-foundation-basics/spring-boot-foundation-basics-final/pom.xml
@@ -32,7 +32,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/s2-spring-boot-foundation-basics/spring-boot-foundation-basics-final/pom.xml
+++ b/s2-spring-boot-foundation-basics/spring-boot-foundation-basics-final/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.7</version>
+		<version>4.1.0</version>
 	</parent>
 
 	<properties>

--- a/s2-spring-boot-foundation-basics/spring-boot-foundation-basics-final/src/main/java/com/thinkenterprise/Application.java
+++ b/s2-spring-boot-foundation-basics/spring-boot-foundation-basics-final/src/main/java/com/thinkenterprise/Application.java
@@ -25,7 +25,6 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.h2.H2ConsoleAutoConfiguration;
 import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
 import org.springframework.context.annotation.ImportRuntimeHints;
 
@@ -34,7 +33,7 @@ import com.thinkenterprise.customize.HelloWorldSpringApplicationEventListener;
 
 import java.util.Arrays;
 
-@SpringBootApplication(exclude = { H2ConsoleAutoConfiguration.class }, scanBasePackageClasses = { Application.class })
+@SpringBootApplication(scanBasePackageClasses = { Application.class })
 @ImportRuntimeHints(ApplicationRuntimeHints.class)
 public class Application implements ApplicationRunner {
 

--- a/s3-spring-boot-foundation-test/spring-boot-foundation-test-final/pom.xml
+++ b/s3-spring-boot-foundation-test/spring-boot-foundation-test-final/pom.xml
@@ -22,8 +22,8 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<maven.surefire.version>3.5.4</maven.surefire.version>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
+		<maven.surefire.version>3.5.2</maven.surefire.version>
 	</properties>
 
 	<dependencyManagement>
@@ -51,7 +51,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-		</dependency>	
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/s3-spring-boot-foundation-test/spring-boot-foundation-test-final/pom.xml
+++ b/s3-spring-boot-foundation-test/spring-boot-foundation-test-final/pom.xml
@@ -42,7 +42,7 @@
 	
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/s3-spring-boot-foundation-test/spring-boot-foundation-test-final/src/main/java/com/thinkenterprise/Application.java
+++ b/s3-spring-boot-foundation-test/spring-boot-foundation-test-final/src/main/java/com/thinkenterprise/Application.java
@@ -22,9 +22,8 @@ package com.thinkenterprise;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.h2.H2ConsoleAutoConfiguration;
 
-@SpringBootApplication(exclude = {H2ConsoleAutoConfiguration.class}, scanBasePackageClasses = {Application.class})
+@SpringBootApplication(scanBasePackageClasses = {Application.class})
 public class Application  {
 	
 	

--- a/s3-spring-boot-foundation-test/spring-boot-foundation-test-final/src/test/java/com/thinkenterprise/test/RouteControllerTest.java
+++ b/s3-spring-boot-foundation-test/spring-boot-foundation-test-final/src/test/java/com/thinkenterprise/test/RouteControllerTest.java
@@ -5,7 +5,7 @@ import com.thinkenterprise.service.RouteService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;

--- a/s3-spring-boot-foundation-test/spring-boot-foundation-test-final/src/test/java/com/thinkenterprise/test/RouteControllerTest.java
+++ b/s3-spring-boot-foundation-test/spring-boot-foundation-test-final/src/test/java/com/thinkenterprise/test/RouteControllerTest.java
@@ -5,14 +5,13 @@ import com.thinkenterprise.service.RouteService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.bean.override.convention.TestBean;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
-import org.springframework.web.client.RestClient;
+import org.springframework.test.web.servlet.client.RestTestClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -20,53 +19,53 @@ import static org.mockito.Mockito.when;
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 @AutoConfigureMockMvc
 public class RouteControllerTest {
-	
-	@Autowired
-	RouteController routeController;
 
-	@LocalServerPort
-	int port;
+    private static final String HELLO_WORLD = "Hello World";
 
-	@MockitoBean
-	RouteService routeService;
+    @Autowired
+    RouteController routeController;
 
-	@TestBean
-	private RestClient restClient;
+    @LocalServerPort
+    int port;
 
-	@Autowired
-	private MockMvcTester mockMvcTester;
+    @MockitoBean
+    RouteService routeService;
 
-	public static RestClient restClient() {
-		return RestClient.create("http://localhost:" + 8080);
-	}
+    private RestTestClient restClient;
 
-	@BeforeEach
-	void setUp() {
-		when(routeService.getHelloWorld()).thenReturn("Hello World");
-	}
-	
-	@Test
-	public void testHelloWorld() {
-		String result = restClient.get().uri("/helloWorld").retrieve().body(String.class);
-		assertThat(result).isEqualTo("Hello World");
-	}
+    @Autowired
+    private MockMvcTester mockMvcTester;
 
-	@Test
-	public void testHelloWorldMockMvcTester() {
-		var result = mockMvcTester.get().uri("/helloWorld").exchange();
-		assertThat(result).hasStatusOk().bodyText().contains("Hello World");
-	}
+    @BeforeEach
+    void setUp() {
+        restClient = RestTestClient.bindToServer().baseUrl("http://localhost:" + port).build();
+        when(routeService.getHelloWorld()).thenReturn(HELLO_WORLD);
+    }
 
-	@Test
-	public void testHelloWorldWithMVCMock() {
-		var result = mockMvcTester.get().uri("/").exchange();
-		assertThat(result).hasStatusOk();
-		assertThat(result).hasViewName("index");
-	}
-	
-	@Test
-	public void testHelloWorldOnController() {
-		String result = routeController.helloWorld();
-		assertThat(result).isEqualTo("Hello World");
-	}
+    @Test
+    public void testHelloWorld() {
+        restClient.get().uri("/helloWorld")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class).isEqualTo(HELLO_WORLD);
+    }
+
+    @Test
+    public void testHelloWorldMockMvcTester() {
+        var result = mockMvcTester.get().uri("/helloWorld").exchange();
+        assertThat(result).hasStatusOk().bodyText().contains("Hello World");
+    }
+
+    @Test
+    public void testHelloWorldWithMVCMock() {
+        var result = mockMvcTester.get().uri("/").exchange();
+        assertThat(result).hasStatusOk();
+        assertThat(result).hasViewName("index");
+    }
+
+    @Test
+    public void testHelloWorldOnController() {
+        String result = routeController.helloWorld();
+        assertThat(result).isEqualTo("Hello World");
+    }
 }

--- a/s3-spring-boot-foundation-test/spring-boot-foundation-test-start/pom.xml
+++ b/s3-spring-boot-foundation-test/spring-boot-foundation-test-start/pom.xml
@@ -22,8 +22,8 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<maven.surefire.version>3.5.4</maven.surefire.version>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
+		<maven.surefire.version>3.5.2</maven.surefire.version>
 	</properties>
 
 	<dependencyManagement>

--- a/s3-spring-boot-foundation-test/spring-boot-foundation-test-start/pom.xml
+++ b/s3-spring-boot-foundation-test/spring-boot-foundation-test-start/pom.xml
@@ -41,7 +41,7 @@
 	
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/s3-spring-boot-foundation-test/spring-boot-foundation-test-start/src/main/java/com/thinkenterprise/Application.java
+++ b/s3-spring-boot-foundation-test/spring-boot-foundation-test-start/src/main/java/com/thinkenterprise/Application.java
@@ -22,9 +22,8 @@ package com.thinkenterprise;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.h2.H2ConsoleAutoConfiguration;
 
-@SpringBootApplication(exclude = {H2ConsoleAutoConfiguration.class}, scanBasePackageClasses = {Application.class})
+@SpringBootApplication(scanBasePackageClasses = {Application.class})
 public class Application  {
 	
 	

--- a/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/pom.xml
+++ b/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/pom.xml
@@ -45,7 +45,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/pom.xml
+++ b/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/pom.xml
@@ -22,8 +22,8 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<maven.surefire.version>3.5.4</maven.surefire.version>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
+		<maven.surefire.version>3.5.2</maven.surefire.version>
 	</properties>
 
 	<dependencyManagement>

--- a/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/src/main/java/com/thinkenterprise/Application.java
+++ b/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/src/main/java/com/thinkenterprise/Application.java
@@ -21,14 +21,13 @@
 package com.thinkenterprise;
 
 
-import com.thinkenterprise.config.RouteProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties(RouteProperties.class)
+//@EnableConfigurationProperties(RouteProperties.class)
+@ConfigurationPropertiesScan
 public class Application {
 
     public static void main(String[] args) {

--- a/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/src/main/java/com/thinkenterprise/config/TestConfiguration.java
+++ b/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/src/main/java/com/thinkenterprise/config/TestConfiguration.java
@@ -20,19 +20,23 @@
 
 package com.thinkenterprise.config;
 
+import com.thinkenterprise.driver.RouteRepositoryDriver;
+import com.thinkenterprise.driver.TestRouteRepositoryDriver;
+import com.thinkenterprise.repository.RouteRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
-import com.thinkenterprise.driver.RouteRepositoryDriver;
-import com.thinkenterprise.driver.TestRouteRepositoryDriver;
-import com.thinkenterprise.repository.RouteRepository;
-
 @Configuration
 @Profile("test")
 @ConditionalOnClass(RouteRepository.class)
 public class TestConfiguration {
+
+    // Nur zur Demonstration der Enable bzw. Scan Funktion für ConfigurationProperties in der Application.java
+    @Autowired
+    private RouteProperties routeProperties;
 
     @Bean
     public RouteRepositoryDriver testRouteRepositoryDriver() {

--- a/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/src/main/java/com/thinkenterprise/registrar/ExampleBeanRegistrar.java
+++ b/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/src/main/java/com/thinkenterprise/registrar/ExampleBeanRegistrar.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2016 Thinkenterprise
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * @author Spring Boot Foundation Training
+ */
+
+package com.thinkenterprise.registrar;
+
+import org.springframework.beans.factory.BeanRegistrar;
+import org.springframework.beans.factory.BeanRegistry;
+import org.springframework.core.env.Environment;
+
+/**
+ * Beispiel: Programmatische Bean-Registrierung mit {@link BeanRegistrar}
+ * (neu in Spring Framework 7 / Spring Boot 4).
+ *
+ * <p>Es gibt damit drei Wege, eine Bean zu registrieren:
+ * <ol>
+ *   <li><b>implizit</b>     &ndash; {@code @Component} + Component-Scan</li>
+ *   <li><b>explizit</b>     &ndash; {@code @Bean}-Methode in einer {@code @Configuration}</li>
+ *   <li><b>programmatisch</b> &ndash; dieser {@code BeanRegistrar}: typsicher,
+ *       gut fuer dynamische/bedingte Registrierung und AOT-/Native-freundlich
+ *       (loest das alte {@code ImportBeanDefinitionRegistrar} /
+ *       {@code BeanDefinitionRegistryPostProcessor} ab).</li>
+ * </ol>
+ *
+ * <p>Der {@code BeanRegistrar} wird <b>nur dann aktiv</b>, wenn man ihn auf einer
+ * {@code @Configuration} importiert. Das ist hier <b>bewusst nicht</b> gemacht,
+ * damit der laufende Anwendungs-Context unveraendert bleibt &ndash; die Klasse
+ * dient ausschliesslich der Demonstration. So wuerde man ihn einschalten:
+ *
+ * <pre>{@code
+ * @Configuration
+ * @Import(ExampleBeanRegistrar.class)
+ * public class RegistrarConfig { }
+ * }</pre>
+ */
+public class ExampleBeanRegistrar implements BeanRegistrar {
+
+    /**
+     * Die einzige Methode des Interface. Wir bekommen zwei Werkzeuge:
+     * die {@link BeanRegistry} (zum Registrieren) und das {@link Environment}
+     * (fuer Bedingungen wie aktive Profile oder Properties).
+     */
+    @Override
+    public void register(BeanRegistry registry, Environment env) {
+
+        // 1) Einfachste Form: Bean per Typ. Spring instanziiert und verkabelt sie selbst.
+        registry.registerBean(RouteGreeter.class);
+
+        // 2) Mit explizitem Bean-Namen.
+        registry.registerBean("englishGreeter", RouteGreeter.class);
+
+        // 3) Mit Customizer (BeanSpec): Scope, Lazy-Init, Beschreibung und ein eigener
+        //    Supplier. Ueber context.bean(...) kommt man an bereits registrierte Beans.
+        registry.registerBean(RouteBanner.class, spec -> spec
+                .prototype()
+                .lazyInit()
+                .description("Banner, programmatisch registriert")
+                .supplier(context -> new RouteBanner(context.bean(RouteGreeter.class))));
+
+        // 4) Bedingte Registrierung ueber das Environment - das programmatische
+        //    Pendant zu @Profile (vgl. ProductionConfiguration / TestConfiguration).
+        if (env.matchesProfiles("production")) {
+            registry.registerBean("activeGreeter", RouteGreeter.class,
+                    spec -> spec.supplier(context -> new RouteGreeter("Welcome aboard")));
+        }
+        else {
+            registry.registerBean("activeGreeter", RouteGreeter.class,
+                    spec -> spec.supplier(context -> new RouteGreeter("Hallo (Test/Default)")));
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Kleine, in sich geschlossene Demo-Typen (kein Bezug zum uebrigen Code).
+    // ------------------------------------------------------------------
+
+    static class RouteGreeter {
+
+        private final String message;
+
+        RouteGreeter() {
+            this("Hello World");
+        }
+
+        RouteGreeter(String message) {
+            this.message = message;
+        }
+
+        String greet() {
+            return message;
+        }
+    }
+
+    static class RouteBanner {
+
+        private final RouteGreeter greeter;
+
+        RouteBanner(RouteGreeter greeter) {
+            this.greeter = greeter;
+        }
+
+        String render() {
+            return "*** " + greeter.greet() + " ***";
+        }
+    }
+}

--- a/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/src/main/java/com/thinkenterprise/registrar/ExampleBeanRegistrar.java
+++ b/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/src/main/java/com/thinkenterprise/registrar/ExampleBeanRegistrar.java
@@ -37,16 +37,15 @@ import org.springframework.core.env.Environment;
  *       {@code BeanDefinitionRegistryPostProcessor} ab).</li>
  * </ol>
  *
- * <p>Der {@code BeanRegistrar} wird <b>nur dann aktiv</b>, wenn man ihn auf einer
- * {@code @Configuration} importiert. Das ist hier <b>bewusst nicht</b> gemacht,
- * damit der laufende Anwendungs-Context unveraendert bleibt &ndash; die Klasse
- * dient ausschliesslich der Demonstration. So wuerde man ihn einschalten:
- *
- * <pre>{@code
- * @Configuration
- * @Import(ExampleBeanRegistrar.class)
- * public class RegistrarConfig { }
- * }</pre>
+ * <p>Aktiviert wird der Registrar ueber {@link RegistrarConfiguration} (dort per
+ * {@code @Import} eingebunden). Damit die Demo den laufenden Anwendungs-Context
+ * nicht beeinflusst, sind die Beans bewusst nebenwirkungsfrei gehalten:
+ * <ul>
+ *   <li>es sind eigenstaendige Demo-Typen ohne Bezug zum uebrigen Code,</li>
+ *   <li>sie werden mit {@code notAutowirable()} markiert, koennen also nie
+ *       versehentlich in andere Beans injiziert werden,</li>
+ *   <li>Abhaengigkeiten werden eindeutig per Namen aufgeloest.</li>
+ * </ul>
  */
 public class ExampleBeanRegistrar implements BeanRegistrar {
 
@@ -58,29 +57,38 @@ public class ExampleBeanRegistrar implements BeanRegistrar {
     @Override
     public void register(BeanRegistry registry, Environment env) {
 
-        // 1) Einfachste Form: Bean per Typ. Spring instanziiert und verkabelt sie selbst.
+        // 1) Einfachste Form: Bean per Typ. Spring instanziiert sie ueber den
+        //    Default-Konstruktor selbst.
         registry.registerBean(RouteGreeter.class);
 
-        // 2) Mit explizitem Bean-Namen.
-        registry.registerBean("englishGreeter", RouteGreeter.class);
+        // 2) Mit explizitem Namen und Customizer (BeanSpec): eigene Beschreibung,
+        //    eigener Supplier und notAutowirable() - die Bean ist damit kein
+        //    Kandidat fuer Autowiring und kann nichts im Context stoeren.
+        registry.registerBean("germanGreeter", RouteGreeter.class, spec -> spec
+                .description("Deutscher Gruss, programmatisch registriert")
+                .notAutowirable()
+                .supplier(context -> new RouteGreeter("Hallo Welt")));
 
-        // 3) Mit Customizer (BeanSpec): Scope, Lazy-Init, Beschreibung und ein eigener
-        //    Supplier. Ueber context.bean(...) kommt man an bereits registrierte Beans.
-        registry.registerBean(RouteBanner.class, spec -> spec
+        // 3) Voller Customizer: Prototype-Scope, Lazy-Init und ein Supplier, der
+        //    ueber den SupplierContext eine andere Bean EINDEUTIG per Namen holt.
+        registry.registerBean("welcomeBanner", RouteBanner.class, spec -> spec
                 .prototype()
                 .lazyInit()
+                .notAutowirable()
                 .description("Banner, programmatisch registriert")
-                .supplier(context -> new RouteBanner(context.bean(RouteGreeter.class))));
+                .supplier(context -> new RouteBanner(context.bean("germanGreeter", RouteGreeter.class))));
 
         // 4) Bedingte Registrierung ueber das Environment - das programmatische
         //    Pendant zu @Profile (vgl. ProductionConfiguration / TestConfiguration).
         if (env.matchesProfiles("production")) {
-            registry.registerBean("activeGreeter", RouteGreeter.class,
-                    spec -> spec.supplier(context -> new RouteGreeter("Welcome aboard")));
+            registry.registerBean("activeGreeter", RouteGreeter.class, spec -> spec
+                    .notAutowirable()
+                    .supplier(context -> new RouteGreeter("Welcome aboard")));
         }
         else {
-            registry.registerBean("activeGreeter", RouteGreeter.class,
-                    spec -> spec.supplier(context -> new RouteGreeter("Hallo (Test/Default)")));
+            registry.registerBean("activeGreeter", RouteGreeter.class, spec -> spec
+                    .notAutowirable()
+                    .supplier(context -> new RouteGreeter("Hallo (Test/Default)")));
         }
     }
 

--- a/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/src/main/java/com/thinkenterprise/registrar/RegistrarConfiguration.java
+++ b/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-final/src/main/java/com/thinkenterprise/registrar/RegistrarConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2016 Thinkenterprise
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * @author Spring Boot Foundation Training
+ */
+
+package com.thinkenterprise.registrar;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Aktiviert den {@link ExampleBeanRegistrar}.
+ *
+ * <p>Ein {@link org.springframework.beans.factory.BeanRegistrar} wird erst wirksam,
+ * wenn er auf einer {@code @Configuration} ueber {@code @Import} eingebunden wird.
+ * Genau das macht diese Klasse &ndash; sie wird vom Component-Scan
+ * (Basis-Paket {@code com.thinkenterprise}) erfasst, daher laeuft der Registrar
+ * beim Hochfahren des Context automatisch mit.
+ *
+ * <p>Die registrierten Beans sind reine Demo-Objekte (siehe {@link ExampleBeanRegistrar}),
+ * mit {@code notAutowirable()} markiert und werden nirgends verwendet &ndash; der
+ * uebrige Anwendungs-Context bleibt unveraendert lauffaehig.
+ */
+@Configuration
+@Import(ExampleBeanRegistrar.class)
+public class RegistrarConfiguration {
+}

--- a/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-start/pom.xml
+++ b/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-start/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
     </dependencies>
 

--- a/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-start/pom.xml
+++ b/s4-spring-boot-foundation-configuration/spring-boot-foundation-configuration-start/pom.xml
@@ -31,8 +31,8 @@
 		<java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <maven.surefire.version>3.5.4</maven.surefire.version>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
+        <maven.surefire.version>3.5.2</maven.surefire.version>
     </properties>
 
     <dependencyManagement>

--- a/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-application-startup/pom.xml
+++ b/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-application-startup/pom.xml
@@ -22,7 +22,7 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
 		<jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
 	</properties>
 

--- a/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-application-startup/pom.xml
+++ b/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-application-startup/pom.xml
@@ -52,7 +52,7 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 			<exclusions>
 				<exclusion>
 					<groupId>org.springframework.boot</groupId>

--- a/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-application-startup/src/main/java/com/thinkenterprise/Application.java
+++ b/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-application-startup/src/main/java/com/thinkenterprise/Application.java
@@ -21,13 +21,10 @@ package com.thinkenterprise;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.h2.H2ConsoleAutoConfiguration;
 import org.springframework.core.metrics.jfr.FlightRecorderApplicationStartup;
 
 @SuppressWarnings("unused")
-@SpringBootApplication(exclude = {
-		H2ConsoleAutoConfiguration.class
-}, scanBasePackageClasses = {
+@SpringBootApplication(scanBasePackageClasses = {
 		Application.class
 })
 public class Application {

--- a/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-final/pom.xml
+++ b/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-final/pom.xml
@@ -22,8 +22,8 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<maven.surefire.version>3.5.4</maven.surefire.version>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
+		<maven.surefire.version>3.5.2</maven.surefire.version>
 	</properties>
 
 	<dependencyManagement>

--- a/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-final/pom.xml
+++ b/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-final/pom.xml
@@ -45,7 +45,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-final/src/main/java/com/thinkenterprise/service/RouteServiceHealthIndicator.java
+++ b/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-final/src/main/java/com/thinkenterprise/service/RouteServiceHealthIndicator.java
@@ -23,8 +23,8 @@ package com.thinkenterprise.service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-start/pom.xml
+++ b/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-start/pom.xml
@@ -41,7 +41,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-start/pom.xml
+++ b/s5-spring-boot-foundation-actuator/spring-boot-foundation-actuator-start/pom.xml
@@ -22,8 +22,8 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<maven.surefire.version>3.5.4</maven.surefire.version>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
+		<maven.surefire.version>3.5.2</maven.surefire.version>
 	</properties>
 
 	<dependencyManagement>

--- a/s6-spring-boot-foundation-data/spring-boot-foundation-data-final/pom.xml
+++ b/s6-spring-boot-foundation-data/spring-boot-foundation-data-final/pom.xml
@@ -41,7 +41,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/s6-spring-boot-foundation-data/spring-boot-foundation-data-final/pom.xml
+++ b/s6-spring-boot-foundation-data/spring-boot-foundation-data-final/pom.xml
@@ -22,8 +22,8 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<maven.surefire.version>3.5.4</maven.surefire.version>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
+		<maven.surefire.version>3.5.2</maven.surefire.version>
 	</properties>
 
 	<dependencyManagement>
@@ -52,12 +52,21 @@
 			<artifactId>h2</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-h2console</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- Dependencies for RabbitMQ usable with testcontainers -->
@@ -68,12 +77,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>postgresql</artifactId>
+			<artifactId>testcontainers-postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/s6-spring-boot-foundation-data/spring-boot-foundation-data-final/src/test/java/com/thinkenterprise/repository/RouteRepositoryDataJpaTest.java
+++ b/s6-spring-boot-foundation-data/spring-boot-foundation-data-final/src/test/java/com/thinkenterprise/repository/RouteRepositoryDataJpaTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.test.annotation.DirtiesContext;
 
 import com.thinkenterprise.domain.route.Route;

--- a/s6-spring-boot-foundation-data/spring-boot-foundation-data-start/pom.xml
+++ b/s6-spring-boot-foundation-data/spring-boot-foundation-data-start/pom.xml
@@ -22,8 +22,8 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<maven.surefire.version>3.5.4</maven.surefire.version>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
+		<maven.surefire.version>3.5.2</maven.surefire.version>
 	</properties>
 	
 	<dependencyManagement>

--- a/s6-spring-boot-foundation-data/spring-boot-foundation-data-start/pom.xml
+++ b/s6-spring-boot-foundation-data/spring-boot-foundation-data-start/pom.xml
@@ -42,7 +42,7 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		
 			

--- a/s6-spring-boot-foundation-data/spring-boot-foundation-data-start/readme.md
+++ b/s6-spring-boot-foundation-data/spring-boot-foundation-data-start/readme.md
@@ -54,6 +54,26 @@ public interface RouteRepository extends CrudRepository<Route, Long> {
 
 
 
+## Test Dependencies hinzufügen
+
+Für den Test-Slice werden die Test-Starter benötigt. Ab Spring Boot 4 ist der
+JPA-Test-Slice in ein eigenes Modul ausgelagert, daher zusätzlich
+`spring-boot-starter-data-jpa-test`:
+
+```xml
+<dependency>
+	<groupId>org.springframework.boot</groupId>
+	<artifactId>spring-boot-starter-test</artifactId>
+	<scope>test</scope>
+</dependency>
+<dependency>
+	<groupId>org.springframework.boot</groupId>
+	<artifactId>spring-boot-starter-data-jpa-test</artifactId>
+	<scope>test</scope>
+</dependency>
+```
+
+
 ## Test schreiben   
 
 

--- a/s7-spring-boot-foundation-rest/spring-boot-foundation-rest-final/pom.xml
+++ b/s7-spring-boot-foundation-rest/spring-boot-foundation-rest-final/pom.xml
@@ -22,8 +22,8 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<maven.surefire.version>3.5.4</maven.surefire.version>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
+		<maven.surefire.version>3.5.2</maven.surefire.version>
 	</properties>
 
 	<dependencyManagement>

--- a/s7-spring-boot-foundation-rest/spring-boot-foundation-rest-final/pom.xml
+++ b/s7-spring-boot-foundation-rest/spring-boot-foundation-rest-final/pom.xml
@@ -41,7 +41,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/s7-spring-boot-foundation-rest/spring-boot-foundation-rest-final/src/test/java/com/thinkenterprise/test/RouteControllerTest.java
+++ b/s7-spring-boot-foundation-rest/spring-boot-foundation-rest-final/src/test/java/com/thinkenterprise/test/RouteControllerTest.java
@@ -20,7 +20,7 @@
 
 package com.thinkenterprise.test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.thinkenterprise.domain.route.Flight;
 import com.thinkenterprise.domain.route.Route;
 import com.thinkenterprise.repository.RouteRepository;

--- a/s7-spring-boot-foundation-rest/spring-boot-foundation-rest-start/pom.xml
+++ b/s7-spring-boot-foundation-rest/spring-boot-foundation-rest-start/pom.xml
@@ -49,7 +49,7 @@
     <dependencies>   
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>    
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/s7-spring-boot-foundation-rest/spring-boot-foundation-rest-start/pom.xml
+++ b/s7-spring-boot-foundation-rest/spring-boot-foundation-rest-start/pom.xml
@@ -31,7 +31,7 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
     </properties>
 
      <dependencyManagement>

--- a/s9-spring-boot-foundation-security/spring-boot-foundation-security-final/pom.xml
+++ b/s9-spring-boot-foundation-security/spring-boot-foundation-security-final/pom.xml
@@ -22,8 +22,8 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<maven.surefire.version>3.5.4</maven.surefire.version>
-		<spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
+		<maven.surefire.version>3.5.2</maven.surefire.version>
 	</properties>
  
 	<dependencyManagement>

--- a/s9-spring-boot-foundation-security/spring-boot-foundation-security-final/pom.xml
+++ b/s9-spring-boot-foundation-security/spring-boot-foundation-security-final/pom.xml
@@ -41,7 +41,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/s9-spring-boot-foundation-security/spring-boot-foundation-security-start/pom.xml
+++ b/s9-spring-boot-foundation-security/spring-boot-foundation-security-start/pom.xml
@@ -50,7 +50,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/s9-spring-boot-foundation-security/spring-boot-foundation-security-start/pom.xml
+++ b/s9-spring-boot-foundation-security/spring-boot-foundation-security-start/pom.xml
@@ -31,8 +31,8 @@
 		<java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <maven.surefire.version>3.5.4</maven.surefire.version>
-		    <spring.boot.version>3.5.7</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
+        <maven.surefire.version>3.5.2</maven.surefire.version>
 	</properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Überblick

Migration des Maven-Multi-Modul-Trainings auf **Spring Boot 4.1.0** (Spring Framework 7 / Spring Security 7 / Jackson 3 / Tomcat 11 / Jakarta EE 11).

Alle `-final`-Projekte wurden migriert, gebaut und funktional verifiziert (App-Start + Endpunkt-/Testlauf). Die `-start`-Übungsvorlagen wurden nur minimal angepasst (i. d. R. nur `spring.boot.version` → `4.1.0`), damit die Teilnehmeraufgaben weiterhin lösbar bleiben.

## Migrierte Module

| Modul | Wesentliche Änderungen |
|---|---|
| **s2-basics** (inkl. `-final-tomcat` WAR) | Parent 4.1.0; H2-Console-`exclude` entfernt (Autoconfig in eigenes Modul ausgelagert) |
| **s3-test** | `RestTestClient` statt `RestClient`-Test; neuer Test-Slice-Starter `spring-boot-starter-webmvc-test`; `@AutoConfigureMockMvc` → `org.springframework.boot.webmvc.test.autoconfigure` |
| **s4-configuration** | Migration; zusätzlich `BeanRegistrar`-Referenzbeispiel (programmatische Bean-Registrierung, neu in SF7) |
| **s5-actuator** (+ application-startup) | Health-Typen `org.springframework.boot.actuate.health.*` → `org.springframework.boot.health.contributor.*` (Modul `spring-boot-health`) |
| **s6-data** | H2-Console-Modul `spring-boot-h2console`; Testcontainers 2.0 (umbenannte ArtifactIds); JPA-Test-Slice `spring-boot-starter-data-jpa-test` |
| **s7-rest** | Jackson 3: `ObjectMapper` `com.fasterxml.jackson.databind` → `tools.jackson.databind` (Annotationen bleiben `com.fasterxml.jackson.annotation`) |
| **s9-security** | Migration; alle gezeigten APIs sind Spring-Security-7-stabil |
| **querschnittlich** | `spring-boot-starter-web` → `spring-boot-starter-webmvc` (in SB4 deprecated) über alle SB4-Module |

## Verifikation

Pro Modul: `mvn` Build grün, App gestartet, Kernfunktion geprüft (z. B. `/routes` → 200, Health-Endpoints, RFC-7807-ProblemDetail, Basic-Auth 401/200). Bekannte umgebungsbedingte Einschränkung: der Testcontainer-Test in s6 ist in dieser Umgebung nicht lauffähig (Docker-Setup), kompiliert aber und ist kein Migrationseffekt.

## Bekannter Ausschluss

- **`s8-message`** wurde **bewusst nicht** migriert und verbleibt auf **Spring Boot 2.7.2**. Grund: Der `spring-boot-starter-webmvc` existiert dort nicht; das Modul wird separat behandelt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
