### PR TITLE
chore: Claude Code project guidance and dependency-review skill

### DIFF
--- a/.claude/skills/review-dependency-prs/SKILL.md
+++ b/.claude/skills/review-dependency-prs/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: review-dependency-prs
+description: >-
+  Prüft und verifiziert Dependency-/Dependabot-Update-PRs (oder manuelle
+  Versions-Bumps) in diesem Spring-Boot-Trainings-Repo. Auslösen, wenn der
+  Nutzer sinngemäß sagt: "prüfe die neuesten PRs / Updates / Dependabot-PRs",
+  "schau dir die offenen PRs an", "läuft das Update noch?", "kann ich das
+  Dependency-Update mergen?". Der Skill kennt die Trainingsprojekt-Struktur
+  (-final = Lösungsprojekte, müssen IMMER bauen/testen/laufen; -start =
+  Teilnehmer-Startprojekte, die bewusst unvollständig/fehlerhaft sein dürfen),
+  die je Modul zu prüfenden Endpunkte sowie den Build-/Test-/Run-Workflow.
+  Fragt IMMER nach, bevor etwas gemergt/gepusht/gelöscht wird.
+---
+
+# Dependency-/Dependabot-PRs prüfen
+
+Dieser Skill kapselt das Wissen über dieses Repository und den Verifikations-Workflow,
+den wir bei der Spring-Boot-4-Migration etabliert haben. Ziel: Update-PRs eigenständig
+fachlich bewerten und dem Nutzer eine klare Merge-Empfehlung geben – **ohne je
+ungefragt zu mergen**.
+
+## Was für ein Projekt ist das?
+
+- **Maven-Multi-Projekt-Trainingsrepo** mit Kapiteln `s0` … `s9`. **Kein** Root-Aggregator-`pom.xml`:
+  jedes Projekt (`*-final`, `*-start`, Varianten) ist ein **eigenständiges Maven-Projekt**
+  mit eigenem `./mvnw` / `./mvnw.cmd`.
+- **`-final` = Referenz-/Lösungsprojekte.** Diese **müssen immer** kompilieren, ihre **Tests
+  müssen grün** sein und die **Anwendung muss starten und über ihren Endpunkt erreichbar** sein.
+  Ein Update darf hier **nichts** kaputt machen. Bricht ein `-final`, ist das ein **echter Befund**.
+- **`-start` = Teilnehmer-Startprojekte** für die Übungen. Sie sind der **Ausgangspunkt**, von dem
+  aus Teilnehmer das `-final` erarbeiten. Sie dürfen **absichtlich unvollständig sein** (auskommentierte
+  Dependencies, `package-info`-Platzhalter, leere `main`, Entities ohne passenden Starter) und
+  **kompilieren teils bewusst nicht**. Ein Build-Fehler im `-start` ist **per se kein Defekt** –
+  er ist nur dann ein Befund, wenn ein Update **vorgegebenes Gerüst** (nicht die Teilnehmer-Aufgabe)
+  bricht. Im Zweifel: gegen `master` vergleichen, ob der Fehler **vorbestand** oder **neu** durch das Update ist.
+- **Varianten** wie `-final-tomcat` (WAR/externer Tomcat) und `-application-startup` (Demo) sind wie
+  `-final` zu behandeln: müssen laufen.
+- **`s8-spring-boot-foundation-messaging` ist ein Sonderfall**: bewusst auf **Spring Boot 2.7.2**
+  belassen (nicht Teil der SB4-Linie), braucht **RabbitMQ**. Updates hier separat/vorsichtig bewerten;
+  nicht mit den SB4-Modulen über einen Kamm scheren.
+
+## Dependabot
+
+- Konfiguriert in `.github/dependabot.yml` (Ökosystem **maven**, **weekly**; **ignoriert
+  spring-boot-Major-Updates**). Erzeugt PRs mit Branch-Präfix `dependabot/maven/...`.
+- Dependabot **pausiert automatisch**, wenn seine PRs länger nicht angefasst werden.
+  Reaktivieren: GitHub → **Insights → Dependency graph → Reiter „Dependabot" → „Check for updates"**
+  (direkt: `https://github.com/Thinkenterprise/spring-boot-foundation-training/network/updates`),
+  bzw. **Settings → Code security → Dependabot version updates → Enable**. Künftig PRs zeitnah
+  mergen/schließen, damit es aktiv bleibt.
+
+## Umgebung / Werkzeuge
+
+- `gh` CLI für PR-Operationen nutzen. Falls nicht im PATH der laufenden Shell, den
+  Installationspfad ermitteln und direkt aufrufen.
+- **Mindestens JDK 21** erforderlich (die Projekte zielen auf Java 21). Build/Run/Tests immer
+  über den **projekteigenen Maven-Wrapper** (`./mvnw` bzw. `./mvnw.cmd`). Das mitgelieferte
+  `verify-app.ps1` ist PowerShell-basiert.
+- Der **Testcontainer-Test** `RouteRepositoryTestcontainerTest` (s6) **benötigt Docker**. Fehlt
+  Docker, mit `-Dtest=!RouteRepositoryTestcontainerTest` ausschließen und **den Nutzer darauf
+  hinweisen** – ein deswegen nicht ausführbarer Test ist **kein K.-o.-Kriterium** (kein Update-Defekt).
+- Apps laufen auf **Port 8080** – **sequenziell** prüfen und den Java-Prozess nach jedem Check **beenden**.
+
+## Endpunkte & Testlage je Modul (Prüf-Matrix)
+
+| Modul (`-final`) | Tests | App-Checks (Status / erwartet) |
+|---|---|---|
+| `s2-…-basics-final` | – | `GET /` → 200, HTML „Spring Boot Training - Hello World" |
+| `s2-…-basics-final-tomcat` (WAR) | – | `GET /` → 200, „Hallo World" |
+| `s3-…-test-final` | ✅ | `GET /` → 200 · `GET /helloWorld` → „Hello World" |
+| `s4-…-configuration-final` | ✅ | Profil `test` (in `application.properties`) · `GET /routes` → 200 (JSON) · `GET /actuator/health` → 200 |
+| `s5-…-actuator-final` | – | Actuator-Base-Path **`/thinkenterprise`** · `GET /thinkenterprise` → 200 · `GET /thinkenterprise/health` **toggelt UP (200) ↔ DOWN (503)** über einen `@Scheduled`-Custom-Indicator `routeService` – **503 ist KEIN Fehler**; mehrfach pollen, um beide Zustände zu sehen |
+| `s5-…-actuator-application-startup` | – | `GET /` → 200 (läuft auf **Jetty**) |
+| `s6-…-data-final` | ✅ (22) | **kein** Web-Controller · `GET /h2-console` → 200 · Testcontainer-Test ausschließen, s. o. |
+| `s7-…-rest-final` | ✅ (8) | `GET /routes/101` → 200 · `GET /routes/110000` → **400** (RFC-7807 ProblemDetail) |
+| `s9-…-security-final` | ✅ (2) | `GET /routes` ohne Auth → **401** · mit Basic `user:password` → 200 (JSON) |
+| `s8-…-messaging-final` | (Sonderfall) | SB 2.7.2, braucht RabbitMQ – separat bewerten |
+
+Endpunkte/Erwartungen ggf. am Code gegenprüfen (Controller-Mappings, `application.properties`/`.yml`,
+`SecurityConfiguration`), falls sich etwas geändert hat – nicht blind auf diese Tabelle verlassen.
+
+## Workflow: Update-PRs prüfen
+
+1. **PRs auflisten.**
+   `gh pr list --state open --json number,title,headRefName,createdAt`
+   - Keine offenen PRs? → Hinweis geben, dass Dependabot evtl. pausiert ist (s. o.), und fragen,
+     ob der Nutzer es manuell anstoßen will. (Manuelles Triggern geht nur über die GitHub-UI.)
+2. **Pro PR analysieren, was sich wo ändert.**
+   `gh pr diff <n>` bzw. `gh pr view <n> --json files` → betroffene **Module** bestimmen
+   (welche `pom.xml`/welcher Code?). Notieren: alte → neue Version, betroffene Projekte.
+3. **PR auschecken.** `gh pr checkout <n>` (sauberer Working Tree vorausgesetzt).
+4. **Betroffene `-final` (+ `-final-tomcat`, `-application-startup`) verifizieren:**
+   Build **inkl. Tests** und **App-Start + Endpunkt-Check**. Dafür das mitgelieferte Skript nutzen:
+   `& "$PSScriptRoot\verify-app.ps1" -ModuleDir <pfad> -Checks @("URL;;AUTH;;LABEL", ...)`
+   (Pfad zum Skript: `.claude\skills\review-dependency-prs\verify-app.ps1`).
+   - s6: `-ExtraMvn "-Dtest=!RouteRepositoryTestcontainerTest"` setzen, falls kein Docker.
+   - Module ohne Web-Endpunkt nur bauen/testen.
+5. **Betroffene `-start` bewerten:** `./mvnw -q clean compile` (bzw. `test-compile`). Ergebnis
+   **klassifizieren**: kompiliert = ok; erwarteter Fehler (Teilnehmer-Lücke, z. B. s6 `jakarta.persistence`
+   ohne JPA-Starter, s2 auskommentierter Parent) = ok; **unerwarteter** neuer Fehler im vorgegebenen
+   Gerüst = Befund. Im Zweifel `git diff origin/master -- <start-pfad>` prüfen.
+6. **Zurückmelden** – kompakt und ehrlich:
+   - Was wurde aktualisiert (Dependency, alt→neu), welche Projekte betroffen.
+   - Pro Projekt: Build/Tests grün? App erreichbar (mit Status-Codes)?
+   - Echte Befunde **klar von** Umgebungs-Limits (Docker) und **gewollten `-start`-Lücken trennen**.
+7. **Merge-Empfehlung + Rückfrage.** Wenn alles passt: sagen, dass gemergt werden **kann**, und
+   **ausdrücklich fragen, ob gemergt werden soll**. **NIEMALS ungefragt mergen.**
+8. **Nach bestätigtem Merge:** mit `gh pr merge <n>` mergen (Methode erfragen, falls relevant),
+   dann aufräumen: `git checkout master && git pull --prune`, lokalen PR-Branch löschen.
+
+## Feste Regeln
+
+- **Immer fragen** vor `merge`, `push`, `--force`, Branch-Löschen oder anderen Remote-/Außenwirkungen.
+  Eine Freigabe gilt nur für den konkreten Schritt, nicht pauschal.
+- `-final`-Bruch = echter Befund. `-start`-Bruch erst nach Abgleich (vorbestehend/gewollt vs. neu) bewerten.
+- Docker-loser Testcontainer-Fehler und gewollte `-start`-Lücken sind **keine** Update-Regressionen.
+- Java-Prozesse nach jedem App-Check beenden; Port 8080 sequenziell nutzen; Working Tree sauber hinterlassen.

--- a/.claude/skills/review-dependency-prs/verify-app.ps1
+++ b/.claude/skills/review-dependency-prs/verify-app.ps1
@@ -1,0 +1,104 @@
+<#
+.SYNOPSIS
+  Baut ein Maven-Projekt (inkl. Tests), startet das Artefakt (jar/war),
+  pollt den Port, ruft definierte Endpunkte ab und beendet den Prozess wieder.
+
+.DESCRIPTION
+  Verifikations-Helfer für die Spring-Boot-Trainingsprojekte. Wird vom Skill
+  "review-dependency-prs" genutzt, kann aber auch direkt aufgerufen werden.
+
+.EXAMPLE
+  ./verify-app.ps1 -ModuleDir "...\s9-...-security-final" `
+      -Checks @("http://localhost:8080/routes;;;;noauth-erw-401",
+                "http://localhost:8080/routes;;user:password;;auth-erw-200")
+
+.NOTES
+  Check-Format pro Eintrag:  "URL;;AUTH;;LABEL"
+    - AUTH optional als "user:pass" (HTTP Basic). Leer lassen -> kein Auth.
+    - LABEL optional (nur fuer die Ausgabe).
+  Nicht-2xx-Antworten (401/400/503 ...) sind KEIN Skriptfehler -> -SkipHttpErrorCheck.
+#>
+param(
+  [Parameter(Mandatory=$true)][string]$ModuleDir,
+  [string]$ExtraMvn = "",            # z.B. "-Dtest=!RouteRepositoryTestcontainerTest"
+  [switch]$SkipTests,
+  [string[]]$Checks = @(),
+  [int]$Port = 8080,
+  [string]$ReadyUrl = "",            # Default: erste Check-URL
+  [int]$ReadyTimeoutSec = 90
+)
+
+$ErrorActionPreference = "Continue"
+Set-Location $ModuleDir
+Write-Output "########## MODULE: $ModuleDir ##########"
+
+# --- Build (+ Tests, sofern nicht uebersprungen) ---
+$mvnArgs = @("-q","clean","package")
+if ($SkipTests) { $mvnArgs += "-DskipTests" }
+if ($ExtraMvn)  { $mvnArgs += $ExtraMvn.Split(" ") }
+Write-Output ">>> mvnw $($mvnArgs -join ' ')"
+$buildLog = & ".\mvnw.cmd" @mvnArgs 2>&1
+$buildExit = $LASTEXITCODE
+$buildLog | Select-String -Pattern "Tests run:|BUILD SUCCESS|BUILD FAILURE|ERROR|cannot find symbol|does not exist|Caused by" |
+  Select-Object -First 25 | ForEach-Object { Write-Output ("    " + $_.ToString().Trim()) }
+Write-Output ">>> BUILD EXIT: $buildExit"
+if ($buildExit -ne 0) { Write-Output "!!! BUILD FAILED for $ModuleDir"; return }
+
+if ($Checks.Count -eq 0) { Write-Output "(keine Laufzeit-Checks angefordert)"; return }
+
+# --- Artefakt finden (jar/war, *.original ausschliessen) ---
+$art = Get-ChildItem "target\*.jar","target\*.war" -ErrorAction SilentlyContinue |
+       Where-Object { $_.Name -notlike "*.original" } | Select-Object -First 1
+if (-not $art) { Write-Output "!!! Kein Artefakt in target/"; return }
+Write-Output ">>> Starte: $($art.Name)"
+
+$runLog = Join-Path $ModuleDir "run-verify.log"
+Remove-Item $runLog,"$runLog.err" -Force -ErrorAction SilentlyContinue
+$proc = Start-Process -FilePath "java" -ArgumentList @("-jar",$art.FullName) -PassThru `
+          -RedirectStandardOutput $runLog -RedirectStandardError "$runLog.err" -WindowStyle Hidden
+
+function Read-Body($resp) {
+  try {
+    if ($resp.RawContentStream) {
+      $s = [Text.Encoding]::UTF8.GetString($resp.RawContentStream.ToArray())
+    } else { $s = [string]$resp.Content }
+  } catch { $s = [string]$resp.Content }
+  $s = ($s -replace '\s+',' ').Trim()
+  if ($s.Length -gt 200) { $s = $s.Substring(0,[Math]::Min(200,$s.Length)) + "..." }
+  return $s
+}
+
+try {
+  if (-not $ReadyUrl) { $ReadyUrl = ($Checks[0] -split ";;")[0] }
+  $up = $false
+  for ($i=0; $i -lt $ReadyTimeoutSec; $i++) {
+    Start-Sleep -Seconds 1
+    if ($proc.HasExited) { Write-Output "!!! Prozess früh beendet (Code $($proc.ExitCode))"; break }
+    try { Invoke-WebRequest -Uri $ReadyUrl -TimeoutSec 3 -SkipHttpErrorCheck -ErrorAction Stop | Out-Null; $up=$true; break } catch {}
+  }
+  if (-not $up) {
+    Write-Output "!!! App wurde nicht rechtzeitig bereit. Letzte 30 Logzeilen:"
+    if (Test-Path $runLog) { Get-Content $runLog -Tail 30 }
+    if (Test-Path "$runLog.err") { Get-Content "$runLog.err" -Tail 15 }
+    return
+  }
+  Write-Output ">>> App ist oben nach ~$($i+1)s. Checks:"
+  foreach ($c in $Checks) {
+    $parts = $c -split ";;"
+    $url = $parts[0]
+    $auth  = if ($parts.Count -gt 1) { $parts[1] } else { "" }
+    $label = if ($parts.Count -gt 2 -and $parts[2]) { $parts[2] } else { $url }
+    $h = @{}
+    if ($auth) { $h["Authorization"] = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($auth)) }
+    try {
+      $resp = Invoke-WebRequest -Uri $url -Headers $h -TimeoutSec 8 -SkipHttpErrorCheck -ErrorAction Stop
+      Write-Output ("    [{0}] {1} -> HTTP {2} | {3}" -f $label, $url, $resp.StatusCode, (Read-Body $resp))
+    } catch {
+      Write-Output ("    [{0}] {1} -> FEHLER: {2}" -f $label, $url, $_.Exception.Message)
+    }
+  }
+} finally {
+  if (-not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+  Remove-Item $runLog,"$runLog.err" -Force -ErrorAction SilentlyContinue
+  Write-Output ">>> App gestoppt (pid $($proc.Id))"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+Leitfaden für Claude Code in diesem Repository.
+
+## Was ist das?
+
+Ein **Spring-Boot-Schulungs-Repository** (Maven). Es bündelt mehrere voneinander
+unabhängige Trainingsprojekte, gegliedert in Kapitel `s0` … `s9`. **Es gibt kein
+Root-Aggregator-`pom.xml`** – jedes Projekt ist ein **eigenständiges Maven-Projekt**
+mit eigenem `./mvnw` / `./mvnw.cmd`.
+
+## Projekt-Konventionen (wichtig!)
+
+Pro Kapitel gibt es i. d. R. mehrere Projektvarianten:
+
+- **`*-final` = Referenz-/Lösungsprojekte.** Diese **müssen immer** kompilieren, ihre
+  **Tests müssen grün** sein und die **Anwendung muss starten und über ihren Endpunkt
+  erreichbar** sein. Ein Bruch in einem `-final` ist ein **echter Befund**.
+- **`*-start` = Teilnehmer-Startprojekte** für die Übungen – der Ausgangspunkt, von dem
+  aus Teilnehmer das `-final` erarbeiten. Sie dürfen **absichtlich unvollständig oder
+  nicht kompilierbar sein** (auskommentierte Dependencies, `package-info`-Platzhalter,
+  leere `main`, Entities ohne passenden Starter). Ein Build-Fehler im `-start` ist
+  **per se kein Defekt** – nur dann ein Befund, wenn **vorgegebenes Gerüst** (nicht die
+  Teilnehmer-Aufgabe) bricht. Im Zweifel gegen `master` prüfen, ob der Fehler vorbestand.
+- **Varianten** wie `*-final-tomcat` (WAR/externer Tomcat) und `*-application-startup`
+  (Demo) sind wie `-final` zu behandeln: müssen laufen.
+- **`s8-spring-boot-foundation-messaging` ist ein Sonderfall:** bewusst auf
+  **Spring Boot 2.7.2** belassen (nicht Teil der SB4-Linie), braucht **RabbitMQ**.
+  Separat/vorsichtig bewerten, nicht mit den SB4-Modulen vermengen.
+
+Alle übrigen Module laufen auf **der aktuellsten Spring Boot Version**.
+
+## Build / Run / Test
+
+- Immer den **projekteigenen Maven-Wrapper** nutzen (`./mvnw` bzw. `./mvnw.cmd`).
+- **Mindestens JDK 21** erforderlich (die Projekte zielen auf Java 21).
+- Build inkl. Tests: `./mvnw -q clean package`. Anwendung starten: `java -jar target/<artefakt>`.
+- Apps laufen auf **Port 8080** – sequenziell prüfen, Java-Prozess nach dem Check beenden.
+- Der Testcontainer-Test `RouteRepositoryTestcontainerTest` (s6) **benötigt Docker**. Ist Docker
+  nicht verfügbar, lässt er sich mit `-Dtest=!RouteRepositoryTestcontainerTest` ausschließen –
+  den Nutzer darauf hinweisen. Ein deswegen nicht ausführbarer Test ist **kein K.-o.-Kriterium**.
+
+## Dependencies / Dependabot
+
+- **Dependabot** (`.github/dependabot.yml`, maven, weekly; ignoriert spring-boot-Major-Updates)
+  erstellt Update-PRs (`dependabot/maven/...`). Es **pausiert nach Inaktivität** – Reaktivierung
+  über GitHub *Insights → Dependency graph → Dependabot → „Check for updates"*.
+- Zum **Prüfen von Update-/Dependabot-PRs** gibt es den Skill **`review-dependency-prs`**
+  (`.claude/skills/review-dependency-prs/`). Er kennt die Endpunkt-/Test-Matrix je Modul
+  und den vollständigen Verifikations-Workflow. Bei Aufträgen wie „prüfe die neuesten PRs/
+  Updates/Dependabot-PRs" diesen Skill verwenden.
+
+## Arbeitsregeln
+
+- **Immer nachfragen** vor `merge`, `push`, `--force`, Branch-Löschen oder anderen
+  Remote-/Außenwirkungen. Eine Freigabe gilt nur für den konkreten Schritt.
+- Working Tree nach Aktionen sauber hinterlassen; Java-Prozesse nach App-Checks beenden.


### PR DESCRIPTION
## Überblick

Fügt projektlokale Claude-Code-Unterstützung hinzu, damit der Charakter dieses
Trainings-Repos und der Update-Prüf-Workflow nicht jedes Mal neu erklärt werden müssen.

## Inhalt

- **`CLAUDE.md`** — immer geladener Leitfaden: Multi-Projekt-Struktur ohne Root-POM,
  Konventionen (`-final` = Lösungsprojekte, müssen bauen/testen/laufen; `-start` =
  Teilnehmer-Startprojekte, dürfen bewusst unvollständig sein), Build/Run/Test (Minimum **JDK 21**,
  Maven-Wrapper, Port 8080), Dependabot-Hinweise und Arbeitsregeln (vor Remote-Aktionen nachfragen).

- **`.claude/skills/review-dependency-prs/`** — Skill zum Prüfen von Dependency-/Dependabot-Update-PRs:
  - **`SKILL.md`**: Endpunkt-/Test-Matrix je Modul und der vollständige Verifikations-Workflow
    (PRs auflisten → betroffene Module bestimmen → auschecken → `-final` bauen/testen/App prüfen →
    `-start` klassifizieren → zurückmelden → Merge-Empfehlung). **Fragt immer vor dem Merge nach.**
  - **`verify-app.ps1`**: gebündelter Helfer, der ein Modul baut (inkl. Tests), das Artefakt startet,
    den Port pollt, Endpunkte abruft und den Prozess wieder beendet.

## Hinweise

- Dokumentation bezieht sich bewusst auf das **minimal Notwendige** (JDK 21, generischer `gh`-Aufruf),
  nicht auf ein konkretes lokales Setup.
- Der Testcontainer-Test (s6) benötigt Docker; fehlt Docker, ist das **kein K.-o.-Kriterium**.
- Damit der Skill in Claude Code erscheint, ist nach dem Merge ein Session-Neustart nötig
  (projektlokale Skills werden beim Start eingelesen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
